### PR TITLE
Make sqs visibility timeout equal to lambda timeout

### DIFF
--- a/modules/cwe_lambda/modules/lambda/main.tf
+++ b/modules/cwe_lambda/modules/lambda/main.tf
@@ -70,7 +70,7 @@ resource "aws_lambda_function" "cwe_lambda" {
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = var.handler
   source_code_hash = data.archive_file.source.output_base64sha256
-  timeout          = 900
+  timeout          = 60
 
   runtime = var.lambda_runtime
 

--- a/modules/cwe_lambda/modules/sqs_queue/main.tf
+++ b/modules/cwe_lambda/modules/sqs_queue/main.tf
@@ -1,7 +1,8 @@
 resource "aws_sqs_queue" "sqs_queue" {
-  name              = var.queue_name
-  delay_seconds     = var.delay_seconds
-  kms_master_key_id = var.sqs_kms_key_id
+  name                       = var.queue_name
+  delay_seconds              = var.delay_seconds
+  kms_master_key_id          = var.sqs_kms_key_id
+  visibility_timeout_seconds = 60
 }
 
 resource "aws_sqs_queue_policy" "queue_policy" {


### PR DESCRIPTION
Patch: Fixes deployment error from incompatible message and lambda timeout settings