### PR TITLE
Require users to specify lambda package instead of packaging via terraform

### DIFF
--- a/modules/sqs_lambda/main.tf
+++ b/modules/sqs_lambda/main.tf
@@ -39,7 +39,7 @@ module "sqs_dead_letter_queue_policy" {
 module "lambda_endpoint" {
   source                   = "./modules/lambda"
   function_name            = var.function_name
-  source_code_dir          = var.source_code_dir
+  package_location         = var.package_location
   handler                  = var.handler
   lambda_runtime           = var.lambda_runtime
   environment_variable_map = var.environment_variable_map

--- a/modules/sqs_lambda/modules/lambda/variables.tf
+++ b/modules/sqs_lambda/modules/lambda/variables.tf
@@ -1,5 +1,5 @@
-variable "source_code_dir" {
-  description = "Directory holding Lambda source code"
+variable "package_location" {
+  description = "Path for the Lambda deployment package"
   type        = string
 }
 

--- a/modules/sqs_lambda/variables.tf
+++ b/modules/sqs_lambda/variables.tf
@@ -13,8 +13,8 @@ variable "target_id" {
   type        = string
 }
 
-variable "source_code_dir" {
-  description = "Directory holding Lambda source code"
+variable "package_location" {
+  description = "Path for the Lambda deployment package"
   type        = string
 }
 


### PR DESCRIPTION
This change accepts custom lambda packages, in support of the addition of the `reflex package` command.